### PR TITLE
Fixed splitKeyPath undefined issue

### DIFF
--- a/lib/key-path-helpers.js
+++ b/lib/key-path-helpers.js
@@ -2,7 +2,7 @@ const ESCAPED_DOT = /\\\./g
 const ANY_DOT = /\./g
 
 function hasKeyPath (object, keyPath) {
-  var keys = splitKeyPath(keyPath)
+  var keys = this.splitKeyPath(keyPath)
   for (var i = 0, len = keys.length; i < len; i++) {
     var key = keys[i]
     if (object == null || !object.hasOwnProperty(key)) {
@@ -16,7 +16,7 @@ function hasKeyPath (object, keyPath) {
 function getValueAtKeyPath (object, keyPath) {
   if (!keyPath) return object
 
-  var keys = splitKeyPath(keyPath)
+  var keys = this.splitKeyPath(keyPath)
   for (var i = 0, len = keys.length; i < len; i++) {
     var key = keys[i]
     object = object[key]
@@ -28,7 +28,7 @@ function getValueAtKeyPath (object, keyPath) {
 }
 
 function setValueAtKeyPath (object, keyPath, value) {
-  var keys = splitKeyPath(keyPath)
+  var keys = this.splitKeyPath(keyPath)
   while (keys.length > 1) {
     var key = keys.shift()
     if (object[key] == null) {
@@ -40,7 +40,7 @@ function setValueAtKeyPath (object, keyPath, value) {
 }
 
 function deleteValueAtKeyPath (object, keyPath) {
-  var keys = splitKeyPath(keyPath)
+  var keys = this.splitKeyPath(keyPath)
   while (keys.length > 1) {
     var key = keys.shift()
     if (object[key] == null) return;


### PR DESCRIPTION
Hi,

Ran into an issue when using https://github.com/nathanbuchar/electron-settings
`Uncaught ReferenceError: splitKeyPath is not defined`

Traced it to this project and made the following changes.
Im not incredibly proficient with JS so maybe this is an issue which can be fixed in electron-settings, however the change appears benign.

Cheers,
Emmet
